### PR TITLE
Add support for scoping of release markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,36 @@ The API token to create releases at Instana
 
 **Required** The name of the release to create
 
+### `releaseScope`
+
+**Note:** Release scoping is supported in Instana v190 and above; using release scoping with older versions of Instana will not lead to issues, but the scoping specification will be ignored.
+
+**Optional** scoping information for the release in terms of Application Perspectives and Services.
+  The file should contain valid JSON object that satisfies `jq type == 'object'`, and it can have as fields `applications` and `services`, which respectively have the same structure as in the [API documentation for creating releases](https://instana.github.io/openapi/#operation/postRelease), e.g.:
+
+  ```json
+  {
+    "applications": [
+      { "name": "My Awesome App" },
+      { "name": "My Even More Awesome App" },
+    ],
+    "services": [
+      { "name": "Cool service #1" },
+      {
+        "name": "Cool service #2",
+        "scopedTo": {
+          "applications": [
+            { "name": "My Cool App" }
+          ]
+        }
+      }
+    ]
+  }
+  ```
+
+  The JSON snippet above will scope the new release to apply to the entirety of the Application Perspectives `My Awesome App` and `My Even More Awesome App`, to the entirely of the `Cool service #1` service, and to the `Cool service #2` service, but only to what part of `Cool service #2` is included in the `My Cool App` Application Perspective.
+  For more information on Application Perspectives, Services and the scoping, refer to the [Application Monitoring](https://www.instana.com/docs/application_monitoring) documentation.
+
 ## Outputs
 
 ### `id`

--- a/README.md
+++ b/README.md
@@ -58,11 +58,40 @@ The id of the created release
 
 ## Example usage
 
+### Without Release Scoping
+
 ```yaml
-uses: taimos/github-action-instana-release@v1
+uses: taimos/github-action-instana-release@v2
 with:
   releaseName: 'Deployed version 42'
 env:
   INSTANA_BASE: ${{ secrets.INSTANA_BASE }}
   INSTANA_TOKEN: ${{ secrets.INSTANA_TOKEN }}
 ```
+
+### With Release Scoping
+
+```yaml
+uses: taimos/github-action-instana-release@v2
+with:
+  releaseName: 'Deployed version 42'
+  releaseScope: >
+    {
+      "services": [
+        {
+          "name": "spring-webflux",
+          "scopedTo": {
+            "applications": [{ "name": "All Services" }]
+          }
+        },
+        { "name": "spring-boot" }
+      ]
+    }
+env:
+  INSTANA_BASE: ${{ secrets.INSTANA_BASE }}
+  INSTANA_TOKEN: ${{ secrets.INSTANA_TOKEN }}
+```
+
+Notice that, to nest a JSON datastructure in YAML without dealing with conversion issues, we are actually using a YAML multiline string by adding `>` at the beginning of the value for `releaseScope`.
+When using YAML multiline string, each line of the string must be indented at least one level deeper than the key.
+The [YAML Multiline](https://yaml-multiline.info/) is excellent to understand the nuances of multiline in YAML.

--- a/README.md
+++ b/README.md
@@ -1,30 +1,19 @@
 # Github Action for Instana Release markers
 
-This action creates a new release on your Instana tenant
+This action creates a new release on your Instana tenant via the [Instana Pipeline Feedback](https://www.instana.com/docs/pipeline_feedback/) capability.
 
 ## Variables
 
-Set the following variables as secrets for your repository
+Set the following variables as secrets for your repository:
 
-### `INSTANA_BASE`
-
-The base url of your tenant (e.g. `https://test-example.instana.io`)
-
-### `INSTANA_TOKEN`
-
-The API token to create releases at Instana
+* `INSTANA_BASE`: The base url of your tenant (e.g. `https://test-example.instana.io`)
+* `INSTANA_TOKEN`: The API token to create releases at Instana, which _must_ have the `Configuration of releases` permission.
+  Refer to the [Tokens](https://www.instana.com/docs/api/web/#tokens) documentation on the Instana website for more information on how to create API tokens.
 
 ## Inputs
 
-### `releaseName`
-
-**Required** The name of the release to create
-
-### `releaseScope`
-
-**Note:** Release scoping is supported in Instana v190 and above; using release scoping with older versions of Instana will not lead to issues, but the scoping specification will be ignored.
-
-**Optional** scoping information for the release in terms of Application Perspectives and Services.
+* `releaseName` (**required**): The name of the release to create
+* `releaseScope` (**optional**): scoping information for the release in terms of Application Perspectives and Services.
   The file should contain valid JSON object that satisfies `jq type == 'object'`, and it can have as fields `applications` and `services`, which respectively have the same structure as in the [API documentation for creating releases](https://instana.github.io/openapi/#operation/postRelease), e.g.:
 
   ```json
@@ -50,11 +39,11 @@ The API token to create releases at Instana
   The JSON snippet above will scope the new release to apply to the entirety of the Application Perspectives `My Awesome App` and `My Even More Awesome App`, to the entirely of the `Cool service #1` service, and to the `Cool service #2` service, but only to what part of `Cool service #2` is included in the `My Cool App` Application Perspective.
   For more information on Application Perspectives, Services and the scoping, refer to the [Application Monitoring](https://www.instana.com/docs/application_monitoring) documentation.
 
+  **Note:** Release scoping is supported in Instana v190 and above; using release scoping with older versions of Instana will not lead to issues, but the scoping specification will be ignored.
+
 ## Outputs
 
-### `id`
-
-The id of the created release
+* `id`: The id of the newly-created release
 
 ## Example usage
 

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
   releaseName:
     description: 'Name of the release'
     required: true
+  releaseScope:
+    description: 'Scope of the release'
+    required: false
+    default: '{}'
 outputs:
   timide:
     description: 'Release id'
@@ -16,3 +20,4 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.releaseName }}
+    - ${{ inputs.releaseScope }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,12 +2,16 @@
 
 echo "Creating release $1"
 
+echo "${2}" > scope.json
+
 res=$(curl --location --request POST "${INSTANA_BASE}/api/releases" \
   --header "Authorization: apiToken ${INSTANA_TOKEN}" \
   --header "Content-Type: application/json" \
   --data "{
 	\"name\": \"${1}\",
-	\"start\": $(date +%s)000
+	\"start\": $(date +%s)000,
+  \"applications\": $(jq -r '.applications' < scope.json),
+  \"services\": $(jq -r '.services' < scope.json),
 }")
 
 echo $res

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,9 @@ echo "Creating release $1"
 echo "${2}" > scope.json
 
 res=$(curl --location --request POST "${INSTANA_BASE}/api/releases" \
+  --silent \
+  --fail \
+  --show-error \
   --header "Authorization: apiToken ${INSTANA_TOKEN}" \
   --header "Content-Type: application/json" \
   --data "{


### PR DESCRIPTION
With the upcoming Instana v190, there will be support for scoping release markers by Application Perspectives and Services.

This PR introduces support for release marker scoping, as well as some minor cleanup of `entrypoint.sh` to make the GitHub action fail when the release cannot be created, and adding some more content to the `README.md`.