### PR TITLE
Add user-agent header with version

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,6 +15,8 @@ jobs:
       uses: actions/checkout@v2
     - name: Embed version in Dockerfile
       run: sed -i "s/version=dev/version=${{ github.event.inputs.version }}/" Dockerfile
+    - name: Embed version in README.md
+      run: sed -i "s/%%version%%/${{ github.event.inputs.version }}/" README.md
     - name: Create and push release commit and tag
       uses: EndBug/add-and-commit@v7
       with:
@@ -22,7 +24,7 @@ jobs:
         message: "Update version to ${{ github.event.inputs.version }}"
         tag: ${{ github.event.inputs.version }}
         push: origin ${{ github.event.inputs.version }}
-        add: Dockerfile
+        add: .
     - name: Create GitHub release
       uses: actions/create-release@v1
       env:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,32 @@
+name: Release new version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to be used for the new release'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Embed version in Dockerfile
+      run: sed -i "s/version=dev/version=${{ github.event.inputs.version }}/" Dockerfile
+    - name: Create and push release commit and tag
+      uses: EndBug/add-and-commit@v7
+      with:
+        commit_message: "Version ${{ github.event.inputs.version }}"
+        message: "Update version to ${{ github.event.inputs.version }}"
+        tag: ${{ github.event.inputs.version }}
+        push: origin ${{ github.event.inputs.version }}
+        add: Dockerfile
+    - name: Create GitHub release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        release_name: Release ${{ github.event.inputs.version }}
+        tag_name: ${{ github.event.inputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Container image that runs your code
 FROM alpine:3.10
 
+ENV version=dev
+
 RUN apk add --no-cache curl jq
 
 # Copies your code file from your action repository to the filesystem path `/` of the container

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM alpine:3.10
 
 RUN apk add --no-cache curl jq
 
+RUN curl --silent https://api.github.com/repos/taimos/github-action-instana-release/releases/latest | jq -r '.tag_name' > /.version
+
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ ENV version=dev
 
 RUN apk add --no-cache curl jq
 
-RUN curl --silent https://api.github.com/repos/taimos/github-action-instana-release/releases/latest | jq -r '.tag_name' > /.version
-
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Set the following variables as secrets for your repository:
 ### Without Release Scoping
 
 ```yaml
-uses: taimos/github-action-instana-release@v2
+uses: taimos/github-action-instana-release@%%version%%
 with:
   releaseName: 'Deployed version 42'
 env:
@@ -61,7 +61,7 @@ env:
 ### With Release Scoping
 
 ```yaml
-uses: taimos/github-action-instana-release@v2
+uses: taimos/github-action-instana-release@%%version%%
 with:
   releaseName: 'Deployed version 42'
   releaseScope: >

--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ When using YAML multiline string, each line of the string must be indented at le
 The [YAML Multiline](https://yaml-multiline.info/) is excellent to understand the nuances of multiline in YAML.
 
 ## Testing
-To test a new version of this GitHub Action, copy the `test-action.yml` to `.github/workflows`. The test can be executed
+To test a new version of this GitHub Action, copy the `test/test-action.yml` to `.github/workflows`. The test can be executed
 locally with [act](https://github.com/nektos/act).
 ```
-act -s INSTANA_BASE=<<INSTANA_BASE>> -s INSTANA_TOKEN="<<INSTANA_TOKEN>>"
+act -s INSTANA_BASE=<<INSTANA_BASE>> -s INSTANA_TOKEN="<<INSTANA_TOKEN>>" [--env version=<<VERSION>>]
 ```
+The `version` is optional and will be used to identify the user-agent. If not set `dev` will used as version.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Set the following variables as secrets for your repository:
   {
     "applications": [
       { "name": "My Awesome App" },
-      { "name": "My Even More Awesome App" },
+      { "name": "My Even More Awesome App" }
     ],
     "services": [
       { "name": "Cool service #1" },
@@ -84,3 +84,10 @@ env:
 Notice that, to nest a JSON datastructure in YAML without dealing with conversion issues, we are actually using a YAML multiline string by adding `>` at the beginning of the value for `releaseScope`.
 When using YAML multiline string, each line of the string must be indented at least one level deeper than the key.
 The [YAML Multiline](https://yaml-multiline.info/) is excellent to understand the nuances of multiline in YAML.
+
+## Testing
+To test a new version of this GitHub Action, copy the `test-action.yml` to `.github/workflows`. The test can be executed
+locally with [act](https://github.com/nektos/act).
+```
+act -s INSTANA_BASE=<<INSTANA_BASE>> -s INSTANA_TOKEN="<<INSTANA_TOKEN>>"
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,10 @@
 # How to release
 
 Go to the Git Actions panel, and run a `Release new version` manual workflow, specifying the name of the new version (which will be used, among other things, for the tab and the suffix of the user-agent).
+The [Release workflow](.github/workflows/create-release.yml) will:
+
+1. Insert the version in the [Dockerfile](./Dockerfile) and [README.md](./README.md) files, create a new commit and tag it
+2. Build the Docker file and push it to DockerHub
+3. Create a new GitHug Release based on the tag created previously
 
 It's really that simple :-)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+# How to release
+
+Go to the Git Actions panel, and run a `Release new version` manual workflow, specifying the name of the new version (which will be used, among other things, for the tab and the suffix of the user-agent).
+
+It's really that simple :-)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,6 @@ The [Release workflow](.github/workflows/create-release.yml) will:
 
 1. Insert the version in the [Dockerfile](./Dockerfile) and [README.md](./README.md) files, create a new commit and tag it
 2. Build the Docker file and push it to DockerHub
-3. Create a new GitHug Release based on the tag created previously
+3. Create a new GitHub Release based on the tag created previously
 
 It's really that simple :-)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,7 @@ res=$(curl --location --request POST "${INSTANA_BASE}/api/releases" \
   --show-error \
   --header "Authorization: apiToken ${INSTANA_TOKEN}" \
   --header "Content-Type: application/json" \
+  --user-data "taimos/instana-release/${version:-dev}" \
   --data "{
 	\"name\": \"${1}\",
 	\"start\": $(date +%s)000,

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,12 +4,17 @@ echo "Creating release $1"
 
 echo "${2}" > scope.json
 
+version=$(cat /.version)
+
+echo "${INSTANA_BASE} => ${INSTANA_TOKEN}"
+
 res=$(curl --location --request POST "${INSTANA_BASE}/api/releases" \
   --silent \
   --fail \
   --show-error \
   --header "Authorization: apiToken ${INSTANA_TOKEN}" \
   --header "Content-Type: application/json" \
+  --user-agent "taimos/github-action-instana-release/${version}" \
   --data "{
 	\"name\": \"${1}\",
 	\"start\": $(date +%s)000,

--- a/test-action.yml
+++ b/test-action.yml
@@ -1,0 +1,13 @@
+name: Test this action locally with act
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test release
+        uses: ./
+        with:
+          releaseName: 'Github action test'
+        env:
+          INSTANA_BASE: ${{ secrets.INSTANA_BASE }}
+          INSTANA_TOKEN: ${{ secrets.INSTANA_TOKEN }}

--- a/test/release-event.json
+++ b/test/release-event.json
@@ -1,0 +1,6 @@
+{
+  "action": "workflow_dispatch",
+  "inputs": {
+    "version": "1.2.3"
+  }
+}

--- a/test/test-action.yml
+++ b/test/test-action.yml
@@ -1,7 +1,7 @@
 name: Test this action locally with act
 on: push
 jobs:
-  build:
+  test-release:
     runs-on: ubuntu-latest
     steps:
       - name: Test release


### PR DESCRIPTION
# Why

In order to provide better support for Instana release integrations we would like to know about the user agent which sends API requests (including the version). This also helps to get a better understanding of adaption.

# What

Add a simple version file based on the latest git tag which is used for the `curl` requests. The latest version is also fetched by a simple `curl`.
In addition there is a test with https://github.com/nektos/act to test execution locally.
