### PR TITLE
Add user-agent with version to outgoing requests, streamline release process

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,6 +15,8 @@ jobs:
       uses: actions/checkout@v2
     - name: Embed version in Dockerfile
       run: sed -i "s/version=dev/version=${{ github.event.inputs.version }}/" Dockerfile
+    - name: Embed version in README.md
+      run: sed -i "s/%%version%%/${{ github.event.inputs.version }}/" README.md
     - name: Create and push release commit and tag
       uses: EndBug/add-and-commit@v7
       with:
@@ -22,7 +24,7 @@ jobs:
         message: "Update version to ${{ github.event.inputs.version }}"
         tag: ${{ github.event.inputs.version }}
         push: origin ${{ github.event.inputs.version }}
-        add: Dockerfile
+        add: .
     - name: Create GitHub release
       uses: actions/create-release@v1
       env:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,32 @@
+name: Release new version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to be used for the new release'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Embed version in Dockerfile
+      run: sed -i "s/version=dev/version=${{ github.event.inputs.version }}/" Dockerfile
+    - name: Create and push release commit and tag
+      uses: EndBug/add-and-commit@v7
+      with:
+        commit_message: "Version ${{ github.event.inputs.version }}"
+        message: "Update version to ${{ github.event.inputs.version }}"
+        tag: ${{ github.event.inputs.version }}
+        push: origin ${{ github.event.inputs.version }}
+        add: Dockerfile
+    - name: Create GitHub release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        release_name: Release ${{ github.event.inputs.version }}
+        tag_name: ${{ github.event.inputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Container image that runs your code
 FROM alpine:3.10
 
+ENV version=dev
+
 RUN apk add --no-cache curl jq
 
 # Copies your code file from your action repository to the filesystem path `/` of the container

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Set the following variables as secrets for your repository:
 ### Without Release Scoping
 
 ```yaml
-uses: taimos/github-action-instana-release@v2
+uses: taimos/github-action-instana-release@%%version%%
 with:
   releaseName: 'Deployed version 42'
 env:
@@ -61,7 +61,7 @@ env:
 ### With Release Scoping
 
 ```yaml
-uses: taimos/github-action-instana-release@v2
+uses: taimos/github-action-instana-release@%%version%%
 with:
   releaseName: 'Deployed version 42'
   releaseScope: >

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,10 @@
 # How to release
 
 Go to the Git Actions panel, and run a `Release new version` manual workflow, specifying the name of the new version (which will be used, among other things, for the tab and the suffix of the user-agent).
+The [Release workflow](.github/workflows/create-release.yml) will:
+
+1. Insert the version in the [Dockerfile](./Dockerfile) and [README.md](./README.md) files, create a new commit and tag it
+2. Build the Docker file and push it to DockerHub
+3. Create a new GitHug Release based on the tag created previously
 
 It's really that simple :-)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+# How to release
+
+Go to the Git Actions panel, and run a `Release new version` manual workflow, specifying the name of the new version (which will be used, among other things, for the tab and the suffix of the user-agent).
+
+It's really that simple :-)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,6 @@ The [Release workflow](.github/workflows/create-release.yml) will:
 
 1. Insert the version in the [Dockerfile](./Dockerfile) and [README.md](./README.md) files, create a new commit and tag it
 2. Build the Docker file and push it to DockerHub
-3. Create a new GitHug Release based on the tag created previously
+3. Create a new GitHub Release based on the tag created previously
 
 It's really that simple :-)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,7 @@ res=$(curl --location --request POST "${INSTANA_BASE}/api/releases" \
   --show-error \
   --header "Authorization: apiToken ${INSTANA_TOKEN}" \
   --header "Content-Type: application/json" \
+  --user-data "taimos/instana-release/${version:-dev}" \
   --data "{
 	\"name\": \"${1}\",
 	\"start\": $(date +%s)000,


### PR DESCRIPTION
1. Add special user-agent to outgoing requests to be able to track adoption in the wild
2. Streamline release process with a manually-triggered GitHub Actions workflow